### PR TITLE
use simplejson to handle global dynamo Decimal type

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto3
 raven_python_lambda
 swag_client
+simplejson

--- a/s3-forwarder/forwarder.py
+++ b/s3-forwarder/forwarder.py
@@ -8,7 +8,7 @@ import logging
 
 import boto3
 from boto3.dynamodb.types import TypeDeserializer
-import json
+import simplejson as json
 
 from retrying import retry, RetryError
 from swag_client.backend import SWAGManager


### PR DESCRIPTION
Global dynamo add three keys to your data.  One key has a Decimal type and is not serializable with the regular json library.  simplejson handles this.